### PR TITLE
Feature/add filters to bg elements

### DIFF
--- a/backshadow.html
+++ b/backshadow.html
@@ -1,5 +1,5 @@
 <template name="backShadow">
-  <svg id="{{ id }}" class="backshadow coverup {{ className }}" width="100%" height="100%" style="{{ zindex }}">
+  <svg id="{{ this.id }}" class="backshadow coverup {{ this.className }}" width="100%" height="100%" style="{{ this.zindex }}">
     <rect width="100%" height="100%" />
   </svg>
 </template>

--- a/backshadow.js
+++ b/backshadow.js
@@ -8,7 +8,7 @@ BackShadow = {
   wrap: '',
 
   /* show and hide the backshadow */
-  show: function(id, wrap) {
+  show: function(id) {
     this.el = document.getElementById(id);
     this.wrap = document.querySelector('body');
 
@@ -19,7 +19,7 @@ BackShadow = {
     this.wrap.classList.add('backshadow-visible-'+id);
   },
 
-  hide: function(id, wrap) {
+  hide: function(id) {
     this.el = document.getElementById(id);
     this.wrap = document.querySelector('body');
 

--- a/backshadow.js
+++ b/backshadow.js
@@ -1,23 +1,36 @@
 BackShadow = {
+  /* external modules */
   events: new Ballyhoo(),
   cbStack: new CallbackStack(),
 
+  /* store a reference to the elements we interact with */
   el : '',
+  wrap: '',
 
-  show: function(id) {
+  /* show and hide the backshadow */
+  show: function(id, wrap) {
     this.el = document.getElementById(id);
+    this.wrap = document.querySelector('body');
+
     if (this.el.classList.contains('visible'))
       return null;
 
     this.el.classList.add('visible');
+    this.wrap.classList.add('backshadow-visible-'+id);
   },
-  hide: function(id) {
+
+  hide: function(id, wrap) {
     this.el = document.getElementById(id);
+    this.wrap = document.querySelector('body');
+
     if (!this.el.classList.contains('visible'))
       return null;
 
     this.el.classList.remove('visible');
+    this.wrap.classList.remove('backshadow-visible-'+id);
   },
+
+  /* open and close the backshadow element */
   open: function(id, data, callback, callbackStack) {
     BackShadow.events.emit(id+'/open', data || {});
     this.cbStack.store(callbackStack, id);
@@ -26,6 +39,7 @@ BackShadow = {
       requestAnimationFrame(callback);
     }
   },
+
   close: function(id, data, callback) {
     BackShadow.events.emit(id+'/close', data || {});
     this.cbStack.run(id);

--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,5 @@
 Template.backShadow.onCreated(function() {
-  var instance  = this;
+  var instance = this;
   BackShadow.events.on(instance.data.id+'/open', function() {
     BackShadow.show(instance.data.id);
   });
@@ -19,16 +19,3 @@ Template.backShadow.onRendered(function() {
   }, false);
 });
 
-
-Template.backShadow.helpers({
-  id: function() {
-    return Template.instance().data.id;
-  },
-  class: function() {
-    return Template.instance().data.className;
-  },
-  zindex: function() {
-    var zindex = Template.instance().data.zindex;
-    return (zindex) ? 'zindex:'+zindex+';' : '';
-  }
-});


### PR DESCRIPTION
## Scope

add a class of `backshadow-visible-<id>` to the body so that we can easily effect other elements with CSS when backshadow is active, and remove it when inactive

This included some cleanup, removing some unnecessary helpers.
